### PR TITLE
Switch to png input files for butteraugli.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ av-metrics-decoders = { version = "0.1", default-features = false, features = [
 ] }
 average = "0.13.1"
 clap = "2.34.0"
-image = { version = "0.23", default-features = false, features = ["pnm"] }
+image = { version = "0.23", default-features = false, features = ["png"] }
 tempfile = "3.2.0"
 yuv = "0.1.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,13 +171,13 @@ fn compare_frame<T: Pixel, U: Pixel>(
     frame2: &FrameInfo<U>,
 ) -> (f64, Option<f64>) {
     let (_, path1) = Builder::new()
-        .suffix(".ppm")
+        .suffix(".png")
         .tempfile()
         .unwrap()
         .keep()
         .unwrap();
     let (_, path2) = Builder::new()
-        .suffix(".ppm")
+        .suffix(".png")
         .tempfile()
         .unwrap()
         .keep()


### PR DESCRIPTION
butteraugli_main consumes png files now. Switch to png files.